### PR TITLE
Cambiado el nombre del repositorio

### DIFF
--- a/practicas/1.md
+++ b/practicas/1.md
@@ -4,8 +4,8 @@ Añadid abajo un enlace al README.md del repositorio en el que hayáis hecho la 
 
 
 ===
-Repositorio para backend de Si2.info
-https://github.com/iblancasa/Si2.infoGII-IV
+[Repositorio para backend de Si2.info. RecApp](https://github.com/iblancasa/RecApp-IV)
+
 
 Participantes:
 + Israel Blancas Álvarez


### PR DESCRIPTION
Cambiado el nombre del repositorio del proyecto de Si2. Antes no teníamos nombre. Ahora se llama "RecApp".
